### PR TITLE
Remove panic() and os.Exit() and return proper HTTP status and error …

### DIFF
--- a/microservices/ga/datamgr/templateApp.go
+++ b/microservices/ga/datamgr/templateApp.go
@@ -286,13 +286,15 @@ func (a *{{.NameExported}}App) create{{.NameExported}}(w http.ResponseWriter, r 
   htmlData, err := ioutil.ReadAll(r.Body)
   if err != nil {
     log.Println(err)
-    os.Exit(1)
+    respondWithError(w, http.StatusBadRequest, "Invalid request payload")
+	return
   }
 
   err = json.Unmarshal(htmlData, &{{.Name}})
   if err != nil {
     log.Println(err)
-    os.Exit(1)
+    respondWithError(w, http.StatusBadRequest, "Invalid request payload")
+	return
   }
 
   ct := time.Now().UTC()

--- a/microservices/ga/datamgr/templateMain.go
+++ b/microservices/ga/datamgr/templateMain.go
@@ -70,7 +70,7 @@ type httpConfig struct {
 var dbconf = databaseConfig{username: "root", password: "", database: "pavedroad", sslMode: "disable", dbDriver: "postgres", ip: "127.0.0.1", port: "26257"}
 
 // Set default http configuration
-var httpconf = httpConfig{ip: "127.0.0.1", port: "8082", shutdownTimeout: 15, readTimeout: 60, writeTimeout: 60, listenString: "127.0.0.1:8082", logPath: "logs/{{.Name}}.log"}
+var httpconf = httpConfig{ip: "127.0.0.1", port: "8081", shutdownTimeout: 15, readTimeout: 60, writeTimeout: 60, listenString: "127.0.0.1:8081", logPath: "logs/{{.Name}}.log"}
 
 // shutdownTimeout will be initialized based on the default or HTTP_SHUTDOWN_TIMEOUT
 var shutdowTimeout time.Duration

--- a/microservices/ga/datamgr/templateModel.go
+++ b/microservices/ga/datamgr/templateModel.go
@@ -64,8 +64,8 @@ func (t *{{.Name}}) update{{.NameExported}}(db *sql.DB, key string) error {
 
   jb, err := json.Marshal(t)
   if err != nil {
-    log.Println("marshal failed")
-    panic(err)
+    log.Printf("update{{.Name}} json.Marshal failed; Got (%v)\n", err.Error())
+    return(err)
   }
 
   statement := fmt.Sprintf(update, jb, key)
@@ -83,7 +83,9 @@ func (t *{{.Name}}) update{{.NameExported}}(db *sql.DB, key string) error {
 func (t *{{.Name}}) create{{.NameExported}}(db *sql.DB) (string, error) {
   jb, err := json.Marshal(t)
   if err != nil {
-    panic(err)
+	msg := fmt.Sprintf("create{{.Name}} json.Marshal failed; Got (%v)\n", err.Error())
+    log.Printf(msg)
+    return msg, err
   }
 
   statement := fmt.Sprintf("INSERT INTO {{.OrgSQLSafe}}.{{.Name}}({{.Name}}) VALUES('%s') RETURNING {{.NameExported}}UUID", jb)
@@ -171,7 +173,7 @@ func (t *{{.Name}}) get{{.NameExported}}(db *sql.DB, key string, method int) err
   switch err := row.Scan(&uid, &jb); err {
 
   case sql.ErrNoRows:
-    m := fmt.Sprintf("404:name %s does not exist", key)
+    m := fmt.Sprintf("404:Name %s does not exist", key)
     return errors.New(m)
   case nil:
     err = json.Unmarshal(jb, t)
@@ -182,8 +184,8 @@ func (t *{{.Name}}) get{{.NameExported}}(db *sql.DB, key string, method int) err
     t.{{.NameExported}}UUID = uid
     break
   default:
-    //Some error to catch
-    panic(err)
+	  log.Printf("500:get{{.Name}} Select failed; Got (%v)\n", err.Error())
+    return(err)
   }
 
   return nil


### PR DESCRIPTION
Remove development code pertaining to panic and Exit functions and replace them with HTTP status codes and error message payloads