### PR TITLE
Set management call functionality for httpServer

### DIFF
--- a/microservices/ga/datamgr/templateModel.go
+++ b/microservices/ga/datamgr/templateModel.go
@@ -32,9 +32,10 @@ type GenericError struct {
 	} `json:"body"`
 }
 
-// Return list of {{.Name}}s
-//
 // TODO: add method of including sub attributes
+//
+
+// Return list of {{.Name}}s
 //
 // swagger:response {{.Name}}List
 type listResponse struct {

--- a/microservices/ga/datamgr/template_test.go
+++ b/microservices/ga/datamgr/template_test.go
@@ -140,11 +140,12 @@ func TestGetWrongUUID(t *testing.T) {
 
 	checkResponseCode(t, http.StatusNotFound, response.Code)
 }
+/ TODO:
+//  need to assert tests for subattributes being present
+
 // TestCreate
 // Use sample data from new{{.NameExported}}JSON) to create
 // a new record.
-// TODO:
-//  need to assert tests for subattributes being present
 //
 func TestCreate{{.NameExported}}(t *testing.T) {
 	clearTable()

--- a/microservices/ga/workerPool/httpJob.go
+++ b/microservices/ga/workerPool/httpJob.go
@@ -5,30 +5,42 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/google/uuid"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
+	"sync"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 const (
-	HTTPJobType		string = "io.pavedraod.eventcollector.httpjob"
-	ClientTimeout int  = 30
+	//HTTPJobType is type of Job for worker
+        HTTPJobType string = "io.pavedraod.eventcollector.httpjob"
+        //ClientTimeout in microseconds to timeout clients
+        ClientTimeout int = 30
+        //CountMaxOut is the upper limit for tracking countinuos Jobs
+        CountMaxOut int = 10000
 )
 
 type httpJob struct {
-	ctx						context.Context
-	JobID					uuid.UUID				`json:"job_id"`
-	JobType				string					`json:"job_type"`
-	client				*http.Client
-	ClientTimeout int							`json:"client_timeout"`
-	// TODO: FIX to errors or custom errors
-	jobErrors []string
-	JobURL		*url.URL	`json:"job_url"`
-	Stats			httpStats `json:"stats"`
+        ctx           context.Context
+        JobID         uuid.UUID `json:"job_id"`
+        JobType       string    `json:"job_type"`
+        client        *http.Client
+        ClientTimeout int `json:"client_timeout"`
+        // TODO: FIX to errors or custom errors
+        jobErrors  []string
+        JobURL     *url.URL  `json:"job_url"`
+        Stats      httpStats `json:"stats"`
+        ClientID   string    `json:"client_id"` //Possible business client
+        sent       bool      //Internal
+        continuous bool      //Internal
+        count      int       //Tracking times sent for continuos Job
+        startTime  time.Time
+        endTime    time.Time
 }
+
 
 type httpStats struct {
 	RequestTimedOut bool
@@ -36,14 +48,32 @@ type httpStats struct {
 }
 
 // Process methods
+
+//ID:  returns the job ID
 func (j *httpJob) ID() string {
 	return j.JobID.String()
 }
 
+//UUID returns the job UUID
+func (j *httpJob) UUID() uuid.UUID {
+        return j.JobID
+}
+
+//Type: returns the job type
 func (j *httpJob) Type() string {
 	return HTTPJobType
 }
-
+//GetClientID: returns the clientID for the job
+func (j *httpJob) GetClientID() string {
+        return j.ClientID
+}
+//Excount: returns the number of time a continuous job
+//executed for the current session.
+//Currently will not increment past a CountMaxOut 
+func (j *httpJob) ExCount() string {
+        return strconv.FormatInt(int64(j.count), 10)
+}
+//Init: intialize a new job
 func (j *httpJob) Init() error {
 
 	// Generate UUID
@@ -58,24 +88,75 @@ func (j *httpJob) Init() error {
 	if j.ClientTimeout == 0 {
 		j.ClientTimeout = ClientTimeout
 	}
+	/*
+                          defaults
+                        j.sent is  false
+                        j.count is 0
+                        j.continuos is false
+
+        */
+
 
 	j.client = &http.Client{Timeout: time.Duration(j.ClientTimeout) * time.Second}
 
 	return nil
 }
+//MarkSent: Mark job as sent before placing on channel
+func (j *httpJob) MarkSent() {
+        if !j.sent {
+                j.sent = true
+        }
+        if j.continuous && j.count < CountMaxOut {
+                j.count = j.count + 1
 
-func (j *httpJob) Run() (result Result, err error) {
-		req, err := http.NewRequest("GET", j.JobURL.String(), nil)
+        }
+}
+
+//PausedAsSent is used to pause a continuous job.
+//Job remains on jobList but is not sent.
+func (j *httpJob) PausedAsSent() bool {
+        if j.continuous && !j.sent {
+                //After completion a continous job is
+                //is marked as not sent.
+                //Marking here as sent without expectation
+                //for placement on the worker pool.
+                j.sent = true
+                return j.sent
+        }
+        return false
+}
+// GetSent: reports on the jobs status
+func (j *httpJob) GetSent() bool {
+        return j.sent
+}
+
+//SetContinuous: sets the job for continuous execution
+func (j *httpJob) SetContinuous() {
+        j.continuous = true
+
+}
+//IsContinuous: reports if the job is a continuos job
+func (j *httpJob) IsContinuous() bool {
+        return j.continuous
+
+}
+
+//Run: executes the job.
+func (j *httpJob) Run(mWg *sync.WaitGroup) (result Result, err error) {
+	defer mWg.Done()
+	req, err := http.NewRequest("GET", j.JobURL.String(), nil)
 	if err != nil {
 		fmt.Println(err)
 		return nil, err
 	}
 
-	start := time.Now()
+	//start := time.Now()
+	j.startTime = time.Now()
+        j.endTime = j.startTime
 	resp, err := j.client.Do(req)
 
-	end := time.Now()
-	j.Stats.RequestTime = end.Sub(start)
+        j.endTime = time.Now()
+        j.Stats.RequestTime = j.endTime.Sub(j.startTime)
 
   // client errors are handled with errors.New()
   // so there is no defined set to check for
@@ -84,6 +165,8 @@ func (j *httpJob) Run() (result Result, err error) {
 		fmt.Println(err)
 		return nil, err
 	}
+
+	defer resp.Body.Close()
 
 	payload, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -118,20 +201,25 @@ func (j *httpJob) buildMetadata(resp *http.Response) map[string]string {
 
 	return md
 }
-
+// Pause a job
 func (j *httpJob) Pause() (status string, err error) {
+	//Not implemented
+	//Implementation, like PausedAsSent, with logic 
+	//sent  to true and continuous to false if true
 	return "paused", nil
 }
 
+//Shutdown: stop a job?
 func (j *httpJob) Shutdown() error {
+	//Not implemented
 	return nil
 }
-
+//Errors: nill error
 func (j *httpJob) Errors() []error {
 	return nil
 
 }
-
+//Metrics: return the metrics for a job
 func (j *httpJob) Metrics() []byte {
 	jblob, err := json.Marshal(j.Stats)
 	if err != nil {

--- a/microservices/ga/workerPool/httpJob_test.go
+++ b/microservices/ga/workerPool/httpJob_test.go
@@ -23,13 +23,14 @@ func JobTestMain() {
 	go startServer()
 
 	// Wait for server to start
-	time.Sleep(1 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	return
 }
 
 func startServer() {
 	fmt.Println("start httpJob Server")
+	fmt.Println("testing at:", ServerString)
 	e := http.ListenAndServe(ServerString, nil)
 	if e != nil {
 		fmt.Println(e)
@@ -45,8 +46,9 @@ func testEndPoint(w http.ResponseWriter, req *http.Request) {
 }
 
 func TestHTTPJob(t *testing.T) {
+	fmt.Println("TestHTTPJob")
 	j := newJob("http://" + ServerString + EPString)
-	r, e := j.Run()
+	r, e := j.Run(&Mwg)
 
 	if e != nil {
 		t.Errorf("j.Run() failed err = %v; Wanted nil\n", e)
@@ -64,8 +66,9 @@ func TestHTTPJob(t *testing.T) {
 }
 
 func TestHTTPJob_Metrics(t *testing.T) {
+	fmt.Println("TestHTTPJob_Metrics")
 	j := newJob("http://" + ServerString + EPString)
-	_, e := j.Run()
+	_, e := j.Run(&Mwg)
 
 	if e != nil {
 		t.Errorf("j.Run() failed err = %v; Wanted nil\n", e)

--- a/microservices/ga/workerPool/httpScheduler.go
+++ b/microservices/ga/workerPool/httpScheduler.go
@@ -591,9 +591,9 @@ func (s *httpScheduler) RunScheduler(mWg *sync.WaitGroup) error {
 	for {
               actSent = 0
                 fmt.Println("Scheduler Running..")
-		Mmutex.Lock()
+		s.metrics.mutex.Lock()
                 if ChannelsReady {
-			Mmutex.Unlock()
+			s.metrics.mutex.Unlock()
                         listLn = len(s.jobList)
                         if listLn != 0 {
                                 s.MetricInc(schedulerIterations)
@@ -631,7 +631,7 @@ func (s *httpScheduler) RunScheduler(mWg *sync.WaitGroup) error {
                                 s.MetricSet(jobListSize, actSent)
                         }
                 } else {
-			Mmutex.Unlock()
+			s.metrics.mutex.Unlock()
                         fmt.Println("Before worker wait sleep ..")
                         time.Sleep(5 * time.Second)
                 }

--- a/microservices/ga/workerPool/httpScheduler.go
+++ b/microservices/ga/workerPool/httpScheduler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -15,12 +16,16 @@ import (
 // Type of Schedulers
 const (
 	constantIntervaleScheduler = "Constant interval scheduler"
+	//Per Worker
+        trackMaxJobs string = "track_max_job_count"
 )
 
 // Defaults
 const (
 	defaultConstantInterval = 10
 	defaultResponseTimeJobs = 10
+	defaultMaxJobCount      = 20000
+        defaultInitMaxJobCount  = 5000
 )
 
 // Metrics constants
@@ -37,6 +42,23 @@ const (
 	averageJobProcessingTime        = "average_job_processing_time"
 )
 
+var MaxJobCount int //Per Worker
+
+//Clients for testing possible extension
+var testClients = []string{
+        "MT1202",
+        "PR8724",
+        "FB90237",
+        "SC52415",
+}
+
+// SchedulerStatus tracks the scheduler and Results collector 
+type SchedulerStatus struct {
+        SchedulerRunning       bool
+        ResultCollectorRunning bool
+}
+
+
 type httpScheduler struct {
 	jobList               []*httpJob
 	schedulerJobChan      chan Job       // Channel to read jobs from
@@ -44,7 +66,7 @@ type httpScheduler struct {
 	schedulerDone         chan bool      // Shutdown initiated by application
 	schedulerInterrupt    chan os.Signal // Shutdown initiated by OS
 	metrics               httpSchedulerMetrics
-	mux                   *sync.Mutex
+	mutex                   *sync.Mutex
 	schedule              httpSchedule
 }
 
@@ -62,12 +84,24 @@ type httpSchedulerMetrics struct {
 	StartTime time.Time      `json:"start_time"`
 	UpTime    time.Duration  `json:"up_time"`
 	Counters  map[string]int `json:"counters"`
-	mux       *sync.Mutex
+	mutex       *sync.Mutex
 }
 
+//getTestClient is temporary for business client inclusion, remove as needed
+func getTestClient() (clientID string) {
+        //Seed to improve selection
+        rand.Seed(time.Now().UnixNano())
+        return testClients[rand.Intn(len(testClients))]
+
+}
+
+
 func (s *httpScheduler) MetricToJSON() ([]byte, error) {
-	s.metrics.mux.Lock()
-	defer s.metrics.mux.Unlock()
+        if s.metrics.mutex == nil {
+                return nil, nil
+        }
+	s.metrics.mutex.Lock()
+	defer s.metrics.mutex.Unlock()
 	jb, e := json.Marshal(s.metrics)
 	if e != nil {
 		fmt.Println(e)
@@ -77,42 +111,45 @@ func (s *httpScheduler) MetricToJSON() ([]byte, error) {
 }
 
 func (s *httpScheduler) MetricSetStartTime() {
-	s.metrics.mux.Lock()
+	s.metrics.mutex.Lock()
 	s.metrics.StartTime = time.Now()
-	s.metrics.mux.Unlock()
+	s.metrics.mutex.Unlock()
 }
 
 func (s *httpScheduler) MetricUpdateUpTime() (uptime time.Duration) {
-	s.metrics.mux.Lock()
+	s.metrics.mutex.Lock()
+	{
 	ct := time.Now()
 	s.metrics.UpTime = ct.Sub(s.metrics.StartTime)
-	s.metrics.mux.Unlock()
+}
+	s.metrics.mutex.Unlock()
 	return s.metrics.UpTime
 }
 
 func (s *httpScheduler) MetricInc(key string) {
-	s.metrics.mux.Lock()
+	s.metrics.mutex.Lock()
 	s.metrics.Counters[key]++
-	s.metrics.mux.Unlock()
+	s.metrics.mutex.Unlock()
 }
 
 func (s *httpScheduler) MetricSet(key string, value int) {
-	s.metrics.mux.Lock()
+	s.metrics.mutex.Lock()
 	s.metrics.Counters[key] = value
-	s.metrics.mux.Unlock()
+	s.metrics.mutex.Unlock()
 }
 
 func (s *httpScheduler) MetricValue(key string) int {
-	s.metrics.mux.Lock()
-	defer s.metrics.mux.Unlock()
+	s.metrics.mutex.Lock()
+	defer s.metrics.mutex.Unlock()
 	return s.metrics.Counters[key]
 }
 
 // UpdateJobList to a new list safely
+// Expected internal use only.
 func (s *httpScheduler) UpdateJobList(newJobList []*httpJob) {
-	s.mux.Lock()
+	s.mutex.Lock()
 	s.jobList = newJobList
-	s.mux.Unlock()
+	s.mutex.Unlock()
 }
 
 // A []listJobsResponse is a single job but returned as a list
@@ -129,6 +166,7 @@ type listJobsResponse struct {
 
 	//type: of job the represents
 	Type string `json:"type"`
+	ClientID string `json:"client_id"` //For future enhancement
 }
 
 // Required object methods for interface
@@ -142,6 +180,7 @@ func (s *httpScheduler) GetScheduledJobs() ([]byte, error) {
 		newRow.ID = v.JobID.String()
 		newRow.URL = v.JobURL.String()
 		newRow.Type = v.JobType
+		newRow.ClientID = v.ClientID
 		response = append(response, newRow)
 	}
 
@@ -152,6 +191,34 @@ func (s *httpScheduler) GetScheduledJobs() ([]byte, error) {
 	return jb, nil
 }
 
+// StopContinuousJob returns the status for a single job status change request
+func (s *httpScheduler) StopContinuousJob(UUID string) (httpStatusCode int, jsonBlob []byte, err error) {
+        msg := ""
+
+        for ji := range s.jobList {
+                //how to lock
+                if s.jobList[ji].ID() == UUID {
+                        s.mutex.Lock()
+                        if s.jobList[ji].PausedAsSent() {
+                                msg = fmt.Sprintf("Job UUID: %v, was stopped.", UUID)
+                        } else {
+                                msg = fmt.Sprintf("Job UUID: %v, not stopped.", UUID)
+                        }
+                        s.mutex.Unlock()
+                        break
+                }
+        }
+
+        // Not found response
+        if msg == "" {
+                msg = fmt.Sprintf("Job UUID: %v, not found.", UUID)
+                return http.StatusNotFound, []byte(msg), nil
+        }
+      return http.StatusOK, []byte(msg), nil
+
+}
+
+
 // GetScheduleJob returns a single job matching the UUID provided
 func (s *httpScheduler) GetScheduleJob(UUID string) (httpStatusCode int, jsonBlob []byte, err error) {
 	var newRow = listJobsResponse{}
@@ -161,6 +228,7 @@ func (s *httpScheduler) GetScheduleJob(UUID string) (httpStatusCode int, jsonBlo
 			newRow.ID = v.ID()
 			newRow.URL = v.JobURL.String()
 			newRow.Type = v.JobType
+			newRow.ClientID = v.ClientID
 			break
 		}
 	}
@@ -184,48 +252,59 @@ func (s *httpScheduler) GetScheduleJob(UUID string) (httpStatusCode int, jsonBlo
 // Returns httpStatusCode, JSON body, and error code
 func (s *httpScheduler) UpdateScheduleJob(jsonBlob []byte) (httpStatusCode int, jsonb []byte, err error) {
 	var updateData = listJobsResponse{}
-	var oldJobID, newJobID string
-	var newJobList []*httpJob
+	//var oldJobID, newJobID string
+	//var newJobList []*httpJob
 	foundJob := false
 
 	e := json.Unmarshal(jsonBlob, &updateData)
 
 	if e != nil {
-		fmt.Println("Unmarshal failed", e.Error())
 		msg := fmt.Sprintf("{\"error\": \"json.Unmarshal failed\", \"Error\": \"%v\"}", e.Error())
 		return http.StatusBadRequest, []byte(msg), e
 	}
 
-	for _, v := range s.jobList {
-		if v.ID() == updateData.ID {
-			newJob := httpJob{}
-			pu, err := url.Parse(updateData.URL)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(-1)
-			}
-			newJob.JobURL = pu
-			newJob.Init()
-			newJobList = append(newJobList, &newJob)
-			oldJobID = v.ID()
-			newJobID = newJob.ID()
-			foundJob = true
-			continue
+	//TODO: Information on what job status can be updated?
+        //Currently, job could alredy be sent and not continuous
+   for ji := range s.jobList {
+                if s.jobList[ji].ID() == updateData.ID {
+                        //newJob := httpJob{}
+                        pu, err := url.Parse(updateData.URL)
+                        if err != nil {
+                                fmt.Println(err)
+                                msg := fmt.Sprintf("{\"error\": \"bad url: \", \"Error\": \"%v\"}", err)
+                                return http.StatusBadRequest, []byte(msg), err
+                        }
+
+			//Logic adjusted to modify job url and business client,
+                        //Not the JobId
+                        s.mutex.Lock()
+                        //newJob.JobURL = pu
+                        s.jobList[ji].JobURL = pu
+                        if updateData.ClientID != "" {
+                                s.jobList[ji].ClientID = updateData.ClientID
+                        }
+                        s.mutex.Unlock()
+
+			 //Put the udated job on the newlist
+                        //newJobList = append(newJobList, &newJob)
+
+                        foundJob = true
+                        break
+
 		}
-		newJobList = append(newJobList, v)
+
+		//put all other jobs on the newlist
+                //newJobList = append(newJobList, v)
+
 	}
 
 	// Handle 404 for Job not found
 	if !foundJob {
-		msg := fmt.Sprintf("{\"error\": \"Not found\", \"UUID\": %v}", updateData.ID)
+		msg := fmt.Sprintf("{\"error\": \"Not found\", \"UUID\": %s}", updateData.ID)
 		return http.StatusNotFound, []byte(msg), nil
 	}
+	msg := fmt.Sprintf("{\"success\": \"job %s information was updated to Client: %s, URL: %s.\"}", updateData.ID, updateData.ClientID, updateData.URL)
 
-	// Update job list and return
-	s.UpdateJobList(newJobList)
-
-	msg := fmt.Sprintf("{\"success\": \"Old job %v replaced by new job %v\"}",
-		oldJobID, newJobID)
 	return http.StatusOK, []byte(msg), nil
 }
 
@@ -242,15 +321,32 @@ func (s *httpScheduler) CreateScheduleJob(jsonBlob []byte) (httpStatusCode int, 
 		return http.StatusBadRequest, []byte(msg), e
 	}
 
+	/* Future: could call another mircoservice to validate 
+	newJobType.ClientID and return if not valid. */
+
 	newJob := httpJob{}
 	pu, err := url.Parse(newJobType.URL)
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(-1)
+		 msg := fmt.Sprintf("{\"error\": \"bad job url\", \"Error\": \"%v\"}", err)
+                return http.StatusBadRequest, []byte(msg), err
 	}
+	e = newJob.Init()
+	 if e != nil {
+                msg := fmt.Sprintf("{\"error\": \"job init failed\", \"Error\": \"%v\"}", e.Error())
+                return http.StatusInternalServerError, []byte(msg), e
+        }
+        //* See getTestClient comments
+        if len(newJobType.ClientID) == 0 {
+                newJobType.ClientID = getTestClient()
+        }
+
 	newJob.JobURL = pu
-	newJob.Init()
-	s.jobList = append(s.jobList, &newJob)
+        newJob.ClientID = newJobType.ClientID
+	newJob.SetContinuous()
+        s.mutex.Lock()
+        s.jobList = append(s.jobList, &newJob)
+        s.mutex.Unlock()
 
 	msg := fmt.Sprintf("{\"success\": \"new job %v added\"}", newJob.ID())
 	return http.StatusCreated, []byte(msg), nil
@@ -259,29 +355,46 @@ func (s *httpScheduler) CreateScheduleJob(jsonBlob []byte) (httpStatusCode int, 
 // DeleteScheduleJob delete the job with ID == uuid
 // Returns httpStatusCode, JSON body, and error code
 func (s *httpScheduler) DeleteScheduleJob(uuid string) (httpStatusCode int, jsonb []byte, err error) {
-	var newJobList []*httpJob
-	var foundJob = false
 
-	for _, v := range s.jobList {
-		if v.ID() == uuid {
-			foundJob = true
-			continue
-		}
-		newJobList = append(newJobList, v)
-	}
+	pstat := s.removeJob(uuid)
+        msg := ""
 
 	// Handle 404 for Job not found
-	if !foundJob {
-		msg := fmt.Sprintf("{\"error\": \"Not found\", \"UUID\": %v}", uuid)
-		return http.StatusNotFound, []byte(msg), nil
-	}
+	if pstat == http.StatusNotFound {
+		msg = fmt.Sprintf("{\"error\": \"Not found\", \"UUID\": %v}", uuid)
+	} else {
+                msg = fmt.Sprintf("{\"success\": \"Job %v deleted\"}", uuid)
+        }
 
-	// Update job list and return
-	s.UpdateJobList(newJobList)
 
-	msg := fmt.Sprintf("{\"success\": \"Job %v deleted\"}", uuid)
-	return http.StatusOK, []byte(msg), nil
+	return pstat, []byte(msg), nil
 }
+
+// removeJob the job with ID == uuid
+func (s *httpScheduler) removeJob(uuid string) (httpStatusCode int) {
+        var newJobList []*httpJob
+        var foundJob = false
+
+        //TODO: Must uptimize by just adjusting the job status
+        //Jobs in newJoblist might have a status change before
+        //being returned to list in the incorrect status.
+        for _, v := range s.jobList {
+                if v.ID() == uuid {
+                        foundJob = true
+                        continue
+               }
+                newJobList = append(newJobList, v)
+        }
+        // Handle 404 for Job not found
+        if !foundJob {
+                return http.StatusNotFound
+        }
+
+        // Update job list and return
+        s.UpdateJobList(newJobList)
+        return http.StatusOK
+}
+
 
 // Object methods for schedules
 func (s *httpScheduler) GetSchedule() (httpStatusCode int, jsonBlob []byte, err error) {
@@ -304,12 +417,11 @@ func (s *httpScheduler) UpdateSchedule(jsonBlob []byte) (httpStatusCode int, jso
 		return http.StatusInternalServerError, []byte(msg), e
 	}
 
-	s.mux.Lock()
+	s.mutex.Lock()
 	s.schedule.SendIntervalSeconds = us.SendIntervalSeconds
-	s.mux.Unlock()
+	s.mutex.Unlock()
 
-	msg := fmt.Sprintf("{\"Status\": \"Success\", \"New interval seconds\": %v}",
-		s.schedule.SendIntervalSeconds)
+	msg := fmt.Sprintf("{\"Status\": \"Success\", \"New interval seconds\": %v}",s.schedule.SendIntervalSeconds)
 
 	return http.StatusOK, []byte(msg), nil
 }
@@ -324,18 +436,20 @@ func (s *httpScheduler) CreateSchedule(jsonBlob []byte) (httpStatusCode int, jso
 		return http.StatusInternalServerError, []byte(msg), e
 	}
 
-	s.mux.Lock()
+	s.mutex.Lock()
+	{
 	s.schedule.ScheduleType = us.ScheduleType
 	s.schedule.SendIntervalSeconds = us.SendIntervalSeconds
-	s.mux.Unlock()
+}
+	s.mutex.Unlock()
 
-	msg := fmt.Sprintf("{\"Status\": \"Success\", \"New interval seconds\": %v}",
-		s.schedule.SendIntervalSeconds)
+	msg := fmt.Sprintf("{\"Status\": \"Success\", \"New interval seconds\": %v}",s.schedule.SendIntervalSeconds)
 	return http.StatusCreated, []byte(msg), nil
 }
 
 func (s *httpScheduler) DeleteSchedule() (httpStatusCode int, jsonb []byte, err error) {
 
+	//TODO: Create a seperate response channel
 	s.schedulerDone <- true
 	msg := fmt.Sprintf("{\"Status\": \"Success scheduler stopped\"}")
 	return http.StatusOK, []byte(msg), nil
@@ -344,6 +458,8 @@ func (s *httpScheduler) DeleteSchedule() (httpStatusCode int, jsonb []byte, err 
 // SetChannels initializes channels the dispatcher has created inside
 // of the scheduler
 func (s *httpScheduler) SetChannels(j chan Job, r chan Result, b chan bool, i chan os.Signal) {
+	//TODO: This should be getDispatchShedChans, so sheduler can call
+        //and wait if channels are not ready.
 	s.schedulerJobChan = j
 	s.schedulerResponseChan = r
 	s.schedulerDone = b
@@ -352,8 +468,51 @@ func (s *httpScheduler) SetChannels(j chan Job, r chan Result, b chan bool, i ch
 	return
 }
 
+// SetConfigVariable changes the value of a given dispatcher field
+func (s *httpScheduler) SetConfigVariable(name string, value int) (httpStatusCode int, msg []byte, err error) {
+
+        fmt.Println("In scheduler SetConfigVariable")
+
+        switch name {
+        case trackMaxJobs:
+                return s.doSetMaxCount(value)
+        default:
+                return doUnkownCmd(name)
+        }
+}
+
+//doSetMaxCount: is used to set the maximum jobs anticipated per worker
+//Initial test for sheduler setConfig
+
+func (s *httpScheduler) doSetMaxCount(value int) (httpStatusCode int, msg []byte, err error) {
+
+        if value < 0 {
+                value = value * -1
+        }
+        if value > defaultMaxJobCount {
+                value = defaultMaxJobCount
+       }
+
+        old := value
+        s.mutex.Lock()
+        {
+                old = MaxJobCount
+                MaxJobCount = value
+        }
+        s.mutex.Unlock()
+        rmsg := fmt.Sprintf("{\" Status\": \"%s changed from %d to %d\"}",
+                trackMaxJobs, old, value)
+        return http.StatusOK, []byte(rmsg), nil
+}
+
 // Process methods
-func (s *httpScheduler) Init() error {
+func (s *httpScheduler) Init(mo *managementCommands) error {
+
+	var funcPtr interface{}
+        var parmsList []string
+
+        MaxJobCount = defaultInitMaxJobCount
+
 	urlList := []string{
 		"https://api.chucknorris.io/jokes/random",
 		"https://swapi.co/api/people/1/",
@@ -362,59 +521,134 @@ func (s *httpScheduler) Init() error {
 
 	s.metrics.Counters = make(map[string]int)
 
-	s.mux = new(sync.Mutex)
-	s.metrics.mux = new(sync.Mutex)
+	s.mutex = new(sync.Mutex)
+	s.metrics.mutex = new(sync.Mutex)
 	s.schedule.ResponseTimeJobs = defaultResponseTimeJobs
 
 	s.schedule.SendIntervalSeconds = defaultConstantInterval
 	s.schedule.ScheduleType = constantIntervaleScheduler
+
+	//DOING: calls to set scheduler managementCommands
+        parmsList = make([]string, 1, 1)
+        parmsList[0] = "Job_UUID"
+
+        funcPtr = s.StopContinuousJob
+
+        mo.useCommand("stop_job", "Stop running of a continuous job.", resScheduler, parmsList, funcPtr)
+
+        //DOING: calls to set scheduler managementFields
+        funcPtr = s.SetConfigVariable
+        mo.setField(trackMaxJobs, "int", resScheduler, funcPtr)
 
 	for _, u := range urlList {
 		newJob := httpJob{}
 		pu, err := url.Parse(u)
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(-1)
+			//os.Exit(-1)
+			continue
 		}
-		newJob.JobURL = pu
 
 		// Set type and ID and http.Client
-		newJob.Init()
+                em := newJob.Init()
+                if em != nil {
+                        return em
+                }
+
+
+		newJob.JobURL = pu
+                newJob.ClientID = getTestClient()
+		newJob.SetContinuous()
+		s.mutex.Lock()
 		s.jobList = append(s.jobList, &newJob)
+		s.mutex.Unlock()
 	}
 
 	return nil
 }
 
-func (s *httpScheduler) Run() error {
-	go s.RunScheduler()
-	go s.RunResultsReader()
+func (s *httpScheduler) Run(mWg *sync.WaitGroup) error {
+	mWg.Add(2)
+	go s.RunScheduler(mWg)
+	go s.RunResultsReader(mWg)
 
 	return nil
 }
 
-func (s *httpScheduler) RunScheduler() error {
+/*
+First in first out scheduler. Work
+needed to optimize. Cannot lock
+while ranging the list.
+*/
+
+//RunScheduler: start up the scheduler
+func (s *httpScheduler) RunScheduler(mWg *sync.WaitGroup) error {
+	var actSent,listLn int
+        defer mWg.Done()
+        //DONE: framework for sheduler management options in init
+	//Which options fro list?
 	s.MetricSetStartTime()
 	for {
-		s.MetricInc(schedulerIterations)
-		for _, j := range s.jobList {
-			s.schedulerJobChan <- j
-			s.MetricInc(jobsSent)
-			s.MetricSet(currentJobChannelCapacity, cap(s.schedulerJobChan))
-			s.MetricSet(currentJobChannelUtilization, len(s.schedulerJobChan))
-			s.MetricSet(jobListSize, len(s.jobList))
-		}
-		s.MetricUpdateUpTime()
-		select {
-		case <-s.schedulerDone:
-			return nil
-		case <-s.schedulerInterrupt:
-			return nil
-		default:
-			time.Sleep(time.Duration(s.schedule.SendIntervalSeconds) * time.Second)
-		}
-	}
+              actSent = 0
+                fmt.Println("Scheduler Running..")
+		Mmutex.Lock()
+                if ChannelsReady {
+			Mmutex.Unlock()
+                        listLn = len(s.jobList)
+                        if listLn != 0 {
+                                s.MetricInc(schedulerIterations)
+                                //Trying to block modifications to joblist
+                                s.metrics.mutex.Lock()
+                                for curIdx := 0; curIdx < listLn; curIdx++ {
+                                        //Hold lock
+                                        j := s.jobList[curIdx]
+                                        sent := false
+                                        if !j.GetSent() || j.IsContinuous() {
+                                                sent = true
+                                                s.jobList[curIdx].MarkSent()
+                                        }
+                                        //joblist modifications now allowed
+                                        s.metrics.mutex.Unlock()
+
+                                        if sent {
+                                                //Note: Blocking
+                                                j.MarkSent()
+                                                s.schedulerJobChan <- j
+                                                s.MetricInc(jobsSent)
+                                                actSent++
+                                        }
+                                        //joblist could have been modified
+                                        //but we can keep going
+                                        //Set lock for next check on len(s.jobList)
+                                        s.metrics.mutex.Lock()
+
+                                }
+                                //done with joblist
+                                s.metrics.mutex.Unlock()
+                                s.MetricSet(currentJobChannelCapacity, cap(s.schedulerJobChan))
+                                s.MetricSet(currentJobChannelUtilization, len(s.schedulerJobChan))
+                                //s.MetricSet(jobListSize, len(s.jobList))
+                                s.MetricSet(jobListSize, actSent)
+                        }
+                } else {
+			Mmutex.Unlock()
+                        fmt.Println("Before worker wait sleep ..")
+                        time.Sleep(5 * time.Second)
+                }
+                s.MetricUpdateUpTime()
+                select {
+                case <-s.schedulerDone:
+                        return nil
+                case <-s.schedulerInterrupt:
+                        return nil
+               default:
+                        fmt.Println("Before scheduler sleep..")
+                        time.Sleep(time.Duration(s.schedule.SendIntervalSeconds) * time.Second)
+			break
+                }
+        }
 }
+
 
 // ComputeAverageResponseTime Keep track of the last N responses
 func (s *httpScheduler) ComputeAverageResponseTime(jt []int, newTime int) ([]int, int) {
@@ -434,33 +668,49 @@ func (s *httpScheduler) ComputeAverageResponseTime(jt []int, newTime int) ([]int
 	return jt, totalTime / currentLength
 }
 
-func (s *httpScheduler) RunResultsReader() error {
+func (s *httpScheduler) RunResultsReader(mWg *sync.WaitGroup) error {
+	defer mWg.Done()
 	jobTimes := make([]int, 0, s.schedule.ResponseTimeJobs)
 	log.Println("Starting result reader")
 	for {
-		select {
-		case currentResult := <-s.schedulerResponseChan:
-			s.MetricInc(resultsReceived)
-			s.MetricSet(currentResultChannelCapacit, cap(s.schedulerJobChan))
-			s.MetricSet(currentResultChannelUtilization, len(s.schedulerJobChan))
-			log.Printf("Processing response for job ID %v\n", currentResult.Job().ID())
-			j := currentResult.Job()
-			if j.(*httpJob).Stats.RequestTimedOut {
-				s.MetricInc(numberOfJobTimedOut)
-			}
-			jt, avg := s.ComputeAverageResponseTime(jobTimes, int(j.(*httpJob).Stats.RequestTime))
-			s.MetricSet(averageJobProcessingTime, avg)
-			jobTimes = jt
+                        select {
+                        case currentResult := <-s.schedulerResponseChan:
+                                {
+                                        log.Println("Processing response")
+                                        s.MetricInc(resultsReceived)
+                                        s.MetricSet(currentResultChannelCapacit, cap(s.schedulerJobChan))
+                                        s.MetricSet(currentResultChannelUtilization, len(s.schedulerJobChan))
+                                        log.Printf("Processing response for job ID %v\n", currentResult.Job().ID())
+                                       log.Println("Processing response after Printf")
+                                        j := currentResult.Job()
+                                        if j.(*httpJob).Stats.RequestTimedOut {
+                                                s.MetricInc(numberOfJobTimedOut)
+                                        }
+                                        jt, avg := s.ComputeAverageResponseTime(jobTimes, int(j.(*httpJob).Stats.RequestTime))
+                                        s.MetricSet(averageJobProcessingTime, avg)
+                                        jobTimes = jt
+                                        //DOING: take job off s.jobList
+                                        if !j.(*httpJob).IsContinuous() {
+                                                st := s.removeJob(j.(*httpJob).ID())
+                                                if st == http.StatusNotFound {
+                                                        log.Printf("could not remove non-continuos job ID %v, %v\n", currentResult.Job().ID(), "not found")
+                                                }
+                                        }
+                                }
+                        case <-s.schedulerDone:
+                                return nil
+                        case <-s.schedulerInterrupt:
+                                return nil
+                        default:
+                                {
+                                        fmt.Println("Result reader Before Sleep..")
+                                        time.Sleep(1 * time.Second)
+					break
+                                }
 
-		case done := <-s.schedulerDone:
-			if done {
-				return nil
-			}
-
-		case <-s.schedulerInterrupt:
-			return nil
-		}
-	}
+                                //select
+                        }
+        }
 }
 
 func (s *httpScheduler) Pause() []byte {
@@ -474,7 +724,7 @@ func (s *httpScheduler) Shutdown() error {
 }
 
 // Status methods
-// DeleteSchedule stops go scheduler goroutine
+// Metrics return the computed sheduler metrics
 func (s *httpScheduler) Metrics() []byte {
 	jb, e := s.MetricToJSON()
 	if e != nil {

--- a/microservices/ga/workerPool/templateApp.go
+++ b/microservices/ga/workerPool/templateApp.go
@@ -315,6 +315,8 @@ func (a *{{.NameExported}}App) listJobs(w http.ResponseWriter, r *http.Request) 
 	respondWithByte(w, http.StatusOK, jl)
 }
 
+// TODO: decide do kill it or do something with it
+
 {{.GetAllSwaggerDoc}}
 // listSchedule swagger:route GET /api/v1/namespace/{{.Namespace}}/{{.Name}}/EventCollectorSchedulerEndPointLIST schedules listschedule
 //
@@ -322,8 +324,6 @@ func (a *{{.NameExported}}App) listJobs(w http.ResponseWriter, r *http.Request) 
 //
 // Responses:
 //		default: genericError
-
-// TODO: decide do kill it or do something with it
 func (a *{{.NameExported}}App) listSchedule(w http.ResponseWriter, r *http.Request) {
 	respondWithJSON(w, http.StatusOK, "{}")
 }

--- a/microservices/ga/workerPool/templateJob.go
+++ b/microservices/ga/workerPool/templateJob.go
@@ -1,20 +1,36 @@
 {{define "templateJob.go"}}package main
 
+import (
+        "github.com/google/uuid"
+        "sync"
+)
+
+
 // Job interface abstraction for worker pools
 // ID() a unique ID assigned to each job
 // Type() string indicating the type of job
 //   for example, "HTTP Request"
+// ClientID() Client for the job (future usage)
 // Execute executes the job returning a Result
 // Errors returns a list of errors to be logged
 type Job interface {
 	// Process methods
 	ID() string
+	UUID() uuid.UUID
 	Type() string
+	GetClientID() string
 	Init() error
-	Run() (result Result, err error)
+	Run(mWg *sync.WaitGroup) (result Result, err error)
 	Pause() (status string, err error)
 	Shutdown() error
 	Errors() []error
+	GetSent() bool
+        MarkSent()
+        SetContinuous()
+        ExCount() string
+        PausedAsSent() bool
+        IsContinuous() bool
+
 
 	// Status methods
 	Metrics() []byte

--- a/microservices/ga/workerPool/templateMain.go
+++ b/microservices/ga/workerPool/templateMain.go
@@ -5,49 +5,83 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"log"
-	"os"
-	"time"
-
-	"github.com/gorilla/mux"
+       "flag"
+        "fmt"
+        "github.com/gorilla/mux"
+        "log"
+        "net/http"
+        "os"
+        "reflect"
+        "strconv"
+        "strings"
+        "sync"
+        "time"
 )
 
 // Constants to build up a k8s style URL
 const (
 	// {{.NameExported}}APIVersion Version API URL
-	{{.NameExported}}APIVersion string = "/api/{{.APIVersion}}"
+	APIVersion string = "/api/{{.APIVersion}}"
 
 	// {{.NameExported}}NamespaceID Prefix for namespaces
-	{{.NameExported}}NamespaceID string = "namespace"
+	NamespaceID string = "namespace"
 
 	// {{.NameExported}}DefaultNamespace Default namespace
-	{{.NameExported}}DefaultNamespace string = "{{.Namespace}}"
+	DefaultNamespace string = "{{.Namespace}}"
 
 	// {{.NameExported}}ResourceType CRD Type per k8s
-	{{.NameExported}}ResourceType string = "{{.Name}}"
+	ResourceType string = "{{.Name}}"
 
 	// The email or account login used by 3rd party provider
-	{{.NameExported}}Key string = "/{key}"
+	Key string = "/{key}"
 
 	// {{.NameExported}}LivenessEndPoint
-	{{.NameExported}}LivenessEndPoint string = "{{.Liveness}}"
+	LivenessEndPoint string = "{{.Liveness}}"
 
 	// {{.NameExported}}ReadinessEndPoint
-	{{.NameExported}}ReadinessEndPoint string = "{{.Readiness}}"
+	ReadinessEndPoint string = "{{.Readiness}}"
 
 	// {{.NameExported}}MetricsEndPoint
-	{{.NameExported}}MetricsEndPoint string = "{{.Metrics}}"
+	MetricsEndPoint string = "{{.Metrics}}"
 
 	// EventCollectorManagementEndPoint
-	EventCollectorManagementEndPoint string = "management"
+	ManagementEndPoint string = "management"
 
 	// {{.NameExported}}JobsEndPoint
-	{{.NameExported}}JobsEndPoint string = "jobs"
+	JobsEndPoint string = "jobs"
 
 	// {{.NameExported}}SchedulerEndPoint
-	{{.NameExported}}SchedulerEndPoint string = "scheduler"
+	SchedulerEndPoint string = "scheduler"
+)
+
+var (
+        //Resources management Option
+        // managementOptions   managementCommand
+
+        // shutdownTimeout will be initialized based on the
+        //default or HTTP_SHUTDOWN_TIMEOUT
+        shutdowTimeout time.Duration
+
+        // GitTag contains current git tab for this repository
+        GitTag string
+
+	       // Version contains version specified in definitions file
+        Version string
+
+        // Build holds latest git commit hash in short form
+        Build string
+
+        //Mwg is used to support go routines
+        Mwg sync.WaitGroup
+
+        //Mmutex is the main control on critical code sections
+        Mmutex *sync.Mutex
+
+        //ChannelsReady is used to manage channels blocking
+        ChannelsReady bool
+
+        //WorkersDown is a Temp fix to allow worker start and stop
+        WorkersDown int
 )
 
 // {{.NameExported}}App Top level construct containing building blocks
@@ -63,15 +97,18 @@ type {{.NameExported}}App struct {
 	Scheduler Scheduler
 
 	// Live http server is start
-	Live bool
+	LiveHTTPSever bool
 
 	// Ready once dispatcher has complete initialization
-	Ready bool
+	DispatcherReady bool
 
 	httpInterruptChan chan os.Signal
 
 	// Logs
 	accessLog *os.File
+
+	//Resources management Option
+        managementOptions managementCommands
 }
 
 // HTTP server configuration
@@ -87,45 +124,536 @@ type httpConfig struct {
 	accessFile      string
 }
 
+
 // Set default http configuration
-var httpconf = httpConfig{ip: "127.0.0.1", port: "8081", shutdownTimeout: 15, readTimeout: 60, writeTimeout: 60, listenString: "127.0.0.1:8081", logPath: "logs/", diagnosticsFile: "diagnostics.log", accessFile: "access.log"}
+var httpconf = httpConfig{
+        ip:              "127.0.0.1",
+        port:            "8081",
+        shutdownTimeout: 15 * time.Second,
+        readTimeout:     time.Minute,
+        writeTimeout:    time.Minute,
+        listenString:    "127.0.0.1:8081",
+        logPath:         "logs/",
+        diagnosticsFile: "diagnostics.log",
+        accessFile:      "access.log",
+}
 
-// shutdownTimeout will be initialized based on the default or HTTP_SHUTDOWN_TIMEOUT
-var shutdowTimeout time.Duration
+// Options
+const (
+        runConfig     string = "config"     //managementRequest.CommandType
+        runCommand    string = "command"    //managementRequest.CommandType
+        resDispatcher string = "Dispatcher" //Resource Type
+        resScheduler  string = "Scheduler"  //Resource Type
+        resWorker     string = "Worker"     //Resource Type
+        resJob        string = "Job"        //Resource Type
+        MaxCmdParms   int    = 2            //Maximum parameters in runCommand
+)
 
-// GitTag contains current git tab for this repository
-var GitTag string
+var errorInterface interface{}
 
-// Version contains version specified in definitions file
-var Version string
+// CmdParm has parametr information for the functions in managementCommands
+type CmdParm struct {
+        //Go parametr data type
+        DataType string `json:"data_type"`
+        //Function parameter order
+        ParamOrder int `json:"param_order"`
+}
 
-// Build holds latest git commit hash in short form
-var Build string
+// ConfigValue information for the keyed Field in managementCommands
+//
+type ConfigValue struct {
+        //Go data type
+        DataType string `json:"data_type"`
+
+        //Should be Resourse type option
+        Resource string `json:"resource"`
+
+        //Function to set the keyed field
+        funcName interface{} `json:"func_name"`
+}
+
+//MgtCommand has information CommandNames maps in managementCommands
+type MgtCommand struct {
+        // Description of what this command does
+        Description string `json:"description"`
+
+        //Indicate service command will impact.
+        //Should be from  Resource type option
+        Resource string `json:"resource"`
+
+        //Function to process the command
+        funcName interface{} `json:"func_name"`
+
+      //Values to set for command
+        CmdParms map[string]CmdParm
+}
+
+// managementCommands is a list of available commanads and field options
+//
+// swagger:response managementCommands
+type managementCommands struct {
+        // The error message
+        // in: body
+
+        // CommandNamess is a map of valid command names that can be executed
+        // Map key is the name of the command
+        CommandNames map[string]MgtCommand `json:"commands"`
+
+       // Fields is a map of fields that can be changed
+        // CommandNames and Fields are not related
+        //But Fields can be checked when a 'config' command type is called.
+        //Map key is the name of the field that can be set.
+        //value and type for the field is in ConfigValue
+        Fields map[string]ConfigValue `json:"fields"`
+}
+
+// get404Response Not found
+//
+// swagger:response get404Response
+type get404Response struct {
+        // The 404 error message
+        // in: body
+
+        Body struct {
+                // Error message
+                Error string `json:"error"`
+
+                // UUID / key that was not found
+                UUID string `json:"uuid"`
+        }
+}
+
+// genericError
+//
+// swagger:response genericError
+type genericError struct {
+        // in: body
+        // Error message
+        Body struct {
+                Error string `json:"error"`
+        } `json:"body"`
+}
+
+
+// genericResponse
+//
+// swagger:response genericResponse
+type genericResponse struct {
+        // in: body
+        Body struct {
+                // JSON body
+                JSONBody string `json:"json_body"`
+        } `json:"body"`
+}
+
+
+
+//
+// swagger:response metricsResponse
+type metricsResponse struct {
+        // in: body
+        Body struct {
+                // Error message
+                SchedulerMetrics string `json:"scheduler_metrics"`
+                DispatherMetrics string `json:"dispather_metrics"`
+        } `json:"body"`
+}
+
+func (mc *managementCommands) Init() {
+        mc.CommandNames = make(map[string]MgtCommand)
+        mc.Fields = make(map[string]ConfigValue)
+}
+
+//Only processing for functions with a specific return
+//signature. Cannot be used if panic must be avoided.
+//func (mc *managementCommands) callFunc(fn interface{}, params ...interface{}) (result []reflect.Value) {
+func (mc *managementCommands) callFunc(fn interface{}, params ...interface{}) (httpStatusCode int, jsonb []byte, err error) {
+        //result:= make([]reflect.Value,3)
+        f := reflect.ValueOf(fn)
+        //ft := f.Elem()
+        if f.Kind() != reflect.Func {
+                log.Printf("Function interface expected but %v was provide. \n", f.Kind())
+                panic("Unexpected function call.")
+        }
+
+        if f.Type().NumIn() != len(params) {
+                //TODO: How to print function name?
+                log.Printf("Incorrect parametres list for function call.")
+                panic("Incorrect number of function parameters")
+        }
+
+        //Three sepcific return parameters expected
+        if f.Type().NumOut() != 3 {
+                log.Printf("Operation has specific function return requirements.")
+
+               panic("Incorrect number of expected function return parameters")
+        }
+
+        if f.Type().Out(0).Kind() != reflect.Int {
+                log.Printf("Must return a httpStatusCode")
+                panic("Incorrect type for expected httpStatusCode.")
+        }
+        //Specific check for slice of bytes can be done.
+        if f.Type().Out(1).Kind() != reflect.Slice {
+               log.Printf("Must return a byte slice payload")
+
+                panic("Incorrect type for expected payload.")
+        }
+        //if !f.Type().Out(2).Implements(errorInterface) {
+        if f.Type().Out(2).Kind() != reflect.Interface {
+                log.Printf("Must return an error ")
+                panic("Incorrect, error return expecetd.")
+        }
+
+        inputs := make([]reflect.Value, len(params))
+       for k, in := range params {
+                inputs[k] = reflect.ValueOf(in)
+        }
+        result := f.Call(inputs)
+        return int(result[0].Int()), result[1].Bytes(), nil
+}
+
+//FieldParm is the information for Fields in managementCommands
+type FieldParm struct {
+        // Value for field
+        FieldValue string `json:"field_value"`
+
+        // Golang Datatype for field
+        // Supported types not specified, must review
+        DataType string `json:"data_type"`
+}
+
+
+// managementRequest user request to execute a management command
+// swagger:request managementRequest
+type managementRequest struct {
+        // The error message
+        // in: body
+
+        // CommandName is a valid Name that can be executed
+        // from a.managementOptions
+        // Can be blank/nil if CommandType is config
+        // Must be available if CommandType is runCommand
+        CommandName string `json:"command"`
+        //Fields to set if CommandType is config
+        // Must have Fileds[0] if config
+        // Can have 0 or mutiple fields if runCommand
+        Fields map[string]FieldParm `json:"fields"`
+
+        //Resource the command is acting on
+        // Dispatcher, Scheduler, Jobs, Workers
+        Resource string `json:"resource"`
+
+        //Type of request: config or command
+        CommandType string `json:"command_type"`
+}
+
+// useCommand() sets up a new managementOptions.CommandNames[] entry if it does not exist
+//Name:  Short name for the command to execute
+//Desc:  Description of what the command does
+//Resourse: Resourse the command will affect
+//ParamsName: Descriptive ordered name list for the parameters to the command
+//  i.e. paramsName[0] is the descriptive name of the first command.
+//  paramsName of length 0 indicates that there are no parameters
+//ValPtr:  Function to call to execute the command
+func (mc *managementCommands) useCommand(name, desc, resourse string, paramsName []string, valPtr interface{}) {
+        var oldCmd MgtCommand
+        var exist bool
+
+
+        if valPtr == nil {
+                log.Printf("Command %s needs a processing function. \n", name)
+                return
+
+        }
+
+        f := reflect.ValueOf(valPtr)
+        if f.Kind() != reflect.Func {
+                log.Printf("Command %s needs a processing function. \n", name)
+                return
+
+        }
+
+       aLen := f.Type().NumIn()
+        if aLen > MaxCmdParms {
+                log.Printf("Function supporting command: %s has more parameters than expecetd. \n", name)
+                return
+
+        }
+
+        Mmutex.Lock()
+        defer Mmutex.Unlock()
+        oldCmd, exist = mc.CommandNames[name]
+        if !exist {
+                pLen := len(paramsName)
+
+                if pLen != aLen {
+                        log.Printf("Command %s should have %v parameter name(s). \n", name, aLen)
+                        return
+                }
+
+                newParm := make(map[string]CmdParm)
+                if aLen > 0 {
+
+                        for i := 0; i < pLen; i++ {
+                               newCmdParm := CmdParm{
+                                        DataType:   f.Type().In(i).Name(),
+                                        ParamOrder: i,
+                                }
+                                newParm[paramsName[i]] = newCmdParm
+                        }
+                }
+
+                newCMD := MgtCommand{
+                        Description: desc,
+                        Resource:    resourse,
+                        funcName:    valPtr,
+                       CmdParms:    newParm,
+                }
+
+                mc.CommandNames[name] = newCMD
+        } else {
+                log.Printf("Command key taken for: %s with: %+v \n", name, oldCmd)
+
+        }
+}
+
+// setField() sets up a new managementOptions.Field[] if it does not exist
+// A simplified version of useCommand.
+//Name:  Name of resourse option to change.
+//DataType: The Go type of the Name (string or int are only type
+//curenntly implemented)
+//Resourse: Resourse the command will affect (see resResourse constants)
+//ValPtr:  Function to call to process the change
+
+func (mc *managementCommands) setField(name, datatype, resourse string, valPtr interface{}) {
+
+        Mmutex.Lock()
+       defer Mmutex.Unlock()
+
+        oldVal, exist := mc.Fields[name]
+
+        if !exist {
+                newVal := ConfigValue{
+                        DataType: datatype,
+                        Resource: resourse,
+                        funcName: valPtr,
+                }
+
+                mc.Fields[name] = newVal
+        } else {
+                log.Printf("Filed key taken for: %s with: %+v \n", name, oldVal)
+
+        }
+}
+
+/*
+  cmdProcessManagementRequest only supports options
+  from managementOptions.CommandNames[]
+*/
+
+func (mc *managementCommands) cmdProcessManagementRequest(r *managementRequest) (httpStatusCode int, jsonb []byte, err error) {
+        name := r.CommandName
+        msg := ""
+        i := len(name)
+        if i == 0 {
+                msg = fmt.Sprintf("{\"Status\": \"Command name is required.\"}")
+               return http.StatusOK, []byte(msg), nil
+
+        }
+
+        reqCmd, isSup := mc.CommandNames[name]
+
+        if !isSup {
+
+                msg = fmt.Sprintf("{\"Status\": \"Command %s is not supported.\"}", r.CommandName)
+                return http.StatusNotFound, []byte(msg), nil
+        }
+      i = len(reqCmd.CmdParms)
+
+        if i != len(r.Fields) {
+                msg = fmt.Sprintf("{\"Status\": \"Command %s requires %v parameters.\"}", r.CommandName, i)
+                return http.StatusBadRequest, []byte(msg), nil
+
+        }
+        execFunc := reqCmd.funcName
+        if reflect.ValueOf(execFunc).IsNil() {
+                msg = fmt.Sprintf("{\"status\": \"unexpected resourse : %v .\"}", name)
+
+              return http.StatusInternalServerError, []byte(msg), nil
+        }
+
+        //Just a cmmand without any parameters
+        if i == 0 {
+                return mc.callFunc(execFunc)
+
+        }
+        //Now process some limited supported parameter
+
+        //keys := make([]string, i)
+      parms := make([]interface{}, i)
+
+        for m := range reqCmd.CmdParms {
+                //Only int and string currently supported
+                if reqCmd.CmdParms[m].DataType != r.Fields[m].DataType {
+                        //Params datatype should match
+                        msg := fmt.Sprintf("{\"Status\": \"Unexpected data type : %v .\"}", r.Fields[m].DataType)
+                        return http.StatusBadRequest, []byte(msg), nil
+
+                }
+
+                switch strings.ToUpper(reqCmd.CmdParms[m].DataType) {
+               case "STRING":
+                        parms[reqCmd.CmdParms[m].ParamOrder] = r.Fields[m].FieldValue
+                case "INT":
+                        //TODO: Convert fldVal to int
+                        int6FldVal, err := strconv.ParseInt(r.Fields[m].FieldValue, 0, 16)
+                        if err != nil {
+                                msg := fmt.Sprintf("{\"Status\": \"Unexpected data value : %v .\"}", err)
+                                return http.StatusBadRequest, []byte(msg), nil
+                       }
+                        intFldVal := int(int6FldVal)
+                        intStrVal := strconv.Itoa(intFldVal)
+                        if intStrVal != r.Fields[m].FieldValue {
+                                msg := fmt.Sprintf("{\"Status\": \"Unexpected int value : %v .\"}", int6FldVal)
+                                return http.StatusBadRequest, []byte(msg), nil
+                        }
+                        parms[reqCmd.CmdParms[m].ParamOrder] = intFldVal
+
+                default:
+                        msg := fmt.Sprintf("{\"Status\": \"Not a supported data type : %v .\"}", r.Fields[m].DataType)
+                       return http.StatusBadRequest, []byte(msg), nil
+
+                        //switch over datatype
+                }
+                //Range over keys
+        }
+
+        return mc.callFunc(execFunc, parms)
+}
+
+/*
+  configProcessManagementRequest only supports options
+  from managementOptions.Fields[]
+*/
+func (mc *managementCommands) configProcessManagementRequest(r *managementRequest) (httpStatusCode int, jsonb []byte, err error) {
+        i := len(r.Fields)
+        msg := ""
+        if i != 1 {
+                msg = fmt.Sprintf("{\"status\": \"command is implemented for only one resource name.\"}")
+                return http.StatusBadRequest, []byte(msg), nil
+       }
+        keys := make([]string, i)
+        i = 0
+        for k := range r.Fields {
+                keys[i] = k
+                i++
+        }
+        field := keys[0]
+        reqCfig, isSup := mc.Fields[field]
+        if !isSup {
+                msg = fmt.Sprintf("{\"status\": \"not a supported resourse : %v .\"}", field)
+               return http.StatusNotFound, []byte(msg), nil
+        }
+        execFunc := reqCfig.funcName
+        if reflect.ValueOf(execFunc).IsNil() {
+                msg = fmt.Sprintf("{\"status\": \"unexpected resourse : %v .\"}", field)
+                return http.StatusInternalServerError, []byte(msg), nil
+        }
+        fldVal := r.Fields[field].FieldValue
+        fldType := mc.Fields[field].DataType
+
+	/*
+           Note:
+           keys[0]
+           field to set
+           mc.managementOptions.Fields[keys[0]].FuncName
+           function to use to set the field
+           r.FIELDS[
+
+        */
+
+       if strings.ToUpper(fldType) == "STRING" {
+                return mc.callFunc(execFunc, field, fldVal)
+        }
+        if strings.ToUpper(fldType) == "INT" {
+                int6FldVal, err := strconv.ParseInt(fldVal, 0, 16)
+                if err != nil {
+                        msg = fmt.Sprintf("{\"Status\": \"Unexpected data type : %v .\"}", err)
+                        return http.StatusBadRequest, []byte(msg), nil
+
+                }
+                intFldVal := int(int6FldVal)
+                intStrVal := strconv.Itoa(intFldVal)
+
+               if intStrVal != fldVal {
+                        msg = fmt.Sprintf("{\"Status\": \"Unexpected int value : %v .\"}", int6FldVal)
+                        return http.StatusBadRequest, []byte(msg), nil
+                }
+
+                return mc.callFunc(execFunc, field, intFldVal)
+        }
+
+        msg = fmt.Sprintf("{\"Status\": \"Command is not implemented for field type : %v .\"}", fldType)
+        return http.StatusBadRequest, []byte(msg), nil
+}
+
+
+// ProcessManagementRequest executes a management command
+func (mc *managementCommands) ProcessManagementRequest(r managementRequest) (httpStatusCode int, jsonb []byte, err error) {
+
+        switch r.CommandType {
+        case runConfig:
+                return mc.configProcessManagementRequest(&r)
+
+        case runCommand:
+                return mc.cmdProcessManagementRequest(&r)
+
+        default:
+                msg := fmt.Sprintf("{\"Status\": \"Command: %s not implemeted\"}",
+                        r.CommandName)
+                return http.StatusBadRequest, []byte(msg), nil
+        }
+
+}
+
 
 // printVersion
 func printVersion() {
-	fmt.Printf("{\"Version\": \"%v\", \"Build\": \"%v\", \"GitTag\": \"%v\"}\n",
-		Version, Build, GitTag)
-	os.Exit(0)
+	fmt.Printf("{\"Version\": \"%v\", \"Build\": \"%v\", \"GitTag\": \"%v\"}\n", Version, Build, GitTag)
 }
+
+func printError(em error) {
+        fmt.Println(em)
+}
+
 
 // main entry point for server
 func main() {
+	Mmutex = new(sync.Mutex)
 	a := {{.NameExported}}App{}
+        WorkersDown = 0
+
 
 	versionFlag := flag.Bool("v", false, "Print version information")
 	flag.Parse()
 
 	if *versionFlag {
 		printVersion()
+		os.Exit(0)
 	}
 
 	// Setup logging
-	openErrorLogFile(httpconf.logPath + httpconf.diagnosticsFile)
+	e := openErrorLogFile(httpconf.logPath + httpconf.diagnosticsFile)
+	if e != nil {
+                printError(e)
+                os.Exit(0)
+        }
+
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 
-	a.accessLog = openAccessLogFile(httpconf.logPath + httpconf.accessFile)
-
 	a.Initialize()
+	Mwg.Add(1)
 	a.Run(httpconf.listenString)
+	Mwg.Wait()
 }{{/* vim: set filetype=gotexttmpl: */ -}}{{end}}

--- a/microservices/ga/workerPool/templateMain.go
+++ b/microservices/ga/workerPool/templateMain.go
@@ -172,7 +172,7 @@ type ConfigValue struct {
         funcName interface{} `json:"func_name"`
 }
 
-//MgtCommand has information CommandNames maps in managementCommands
+//MgtCommand has information for CommandNames maps in managementCommands
 type MgtCommand struct {
         // Description of what this command does
         Description string `json:"description"`
@@ -313,7 +313,7 @@ func (mc *managementCommands) callFunc(fn interface{}, params ...interface{}) (h
         return int(result[0].Int()), result[1].Bytes(), nil
 }
 
-//FieldParm is the information for Fields in managementCommands
+//FieldParm is the information for Fields in managementRequest
 type FieldParm struct {
         // Value for field
         FieldValue string `json:"field_value"`
@@ -359,6 +359,11 @@ type managementRequest struct {
 func (mc *managementCommands) useCommand(name, desc, resourse string, paramsName []string, valPtr interface{}) {
         var oldCmd MgtCommand
         var exist bool
+
+	//TODO: Modify with name prefixed by resourse code to allow
+        //      unique name by resourse. Currently name conflicts
+        //      are not supported. Also need to return error messages.
+
 
 
         if valPtr == nil {
@@ -429,7 +434,12 @@ func (mc *managementCommands) useCommand(name, desc, resourse string, paramsName
 func (mc *managementCommands) setField(name, datatype, resourse string, valPtr interface{}) {
 
         Mmutex.Lock()
-       defer Mmutex.Unlock()
+        defer Mmutex.Unlock()
+
+	//TODO: Modify with name prefixed by resourse code to allow
+        //      unique name by resourse. Currently name conflicts
+        //      are not supported. Also need to return error messages.
+
 
         oldVal, exist := mc.Fields[name]
 

--- a/microservices/ga/workerPool/templateScheduler.go
+++ b/microservices/ga/workerPool/templateScheduler.go
@@ -1,7 +1,10 @@
 {{define "templateScheduler.go"}}{{.PavedroadInfo}}
 package main
 
-import "os"
+import (
+	"os"
+	"sync"
+)
 
 // Scheduler defines the interfaces a scheduler must implement
 type Scheduler interface {
@@ -18,12 +21,13 @@ type Scheduler interface {
 	UpdateScheduleJob(jsonBlob []byte) (httpStatusCode int, jsonb []byte, err error)
 	CreateScheduleJob(jsonBlob []byte) (httpStatusCode int, jsonb []byte, err error)
 	DeleteScheduleJob(UUID string) (httpStatusCode int, jsonb []byte, err error)
+        StopContinuousJob(UUID string) (httpStatusCode int, jsonb []byte, err error)
 
 	// Execution methods
-	Init() error
+	Init(mo *managementCommands) error
 	SetChannels(chan Job, chan Result, chan bool, chan os.Signal)
 	Shutdown() error
-	Run() error
+	Run(mWg *sync.WaitGroup) error
 	//RestartScheduler() error
 	//RestartResultsCollector() error
 
@@ -35,7 +39,7 @@ type Scheduler interface {
 }
 
 // SchedulerStatus tracks if the scheduler and Results collectors are running
-type SchedulerStatus struct {
-	SchedulerRunning       bool
-	ResultCollectorRunning bool
-}{{/* vim: set filetype=gotexttmpl: */ -}}{{end}}
+//type SchedulerStatus struct {
+//	SchedulerRunning       bool
+//	ResultCollectorRunning bool
+//}{{/* vim: set filetype=gotexttmpl: */ -}}{{end}}

--- a/microservices/ga/workerPool/template_test.go
+++ b/microservices/ga/workerPool/template_test.go
@@ -275,7 +275,7 @@ func TestInitEnv(t *testing.T) {
 
         time.Sleep(5 * time.Second)
 
-        curIp := httpconf.ip
+        curIP := httpconf.ip
         curPort := httpconf.port
         curRt := httpconf.readTimeout.Seconds()
         curWt := httpconf.writeTimeout.Seconds()
@@ -286,14 +286,14 @@ func TestInitEnv(t *testing.T) {
         curStS := strconv.FormatFloat(curSt, 'f', 0, 64)
         curWtS := strconv.FormatFloat(curWt, 'f', 0, 64)
 
-        envIp := os.Getenv("HTTP_IP_ADDR")
+        envIP := os.Getenv("HTTP_IP_ADDR")
         envPort := os.Getenv("HTTP_IP_PORT")
         envRto := os.Getenv("HTTP_READ_TIMEOUT")
         envWto := os.Getenv("HTTP_WRITE_TIMEOUT")
         envSto := os.Getenv("HTTP_SHUTDOWN_TIMEOUT")
         envLog := os.Getenv("HTTP_LOG")
 
-        os.Setenv("HTTP_IP_ADDR", curIp)
+        os.Setenv("HTTP_IP_ADDR", curIP)
        os.Setenv("HTTP_IP_PORT", curPort)
         os.Setenv("HTTP_READ_TIMEOUT", curRtS)
         os.Setenv("HTTP_WRITE_TIMEOUT", curWtS)
@@ -304,8 +304,8 @@ func TestInitEnv(t *testing.T) {
         a.initializeEnvironment()
 
         //expected := "0.0.0.0"
-        if httpconf.ip != curIp {
-                t.Errorf("Expected IP %v; Got %v\n", curIp, httpconf.ip)
+        if httpconf.ip != curIP {
+                t.Errorf("Expected IP %v; Got %v\n", curIP, httpconf.ip)
         }
 
         //expected = "10000"
@@ -348,8 +348,8 @@ func TestInitEnv(t *testing.T) {
         os.Unsetenv("HTTP_WRITE_TIMEOUT")
         os.Unsetenv("HTTP_SHUTDOWN_TIMEOUT")
 
-        if envIp != "" {
-                os.Setenv("HTTP_IP_ADDR", envIp)
+        if envIP != "" {
+                os.Setenv("HTTP_IP_ADDR", envIP)
 
         }
         if envPort != "" {


### PR DESCRIPTION
   Implemented functionality to allow one call to getManagement for
   all the management commands. Current command set might not be
    complete, so additions might be required.
    Had to rearrange some structures to complete the task, so these
    structures are now in templateMain.go.

    Testing was challenging because of a number of reasons, so careful
    review and testing will be required.

    The testing screen prints are still in the files. It is easier to
    review what is happening with this output. I can do a direct search
    and remove against the template files after review is completed. I
    will also do a spell check, and message review at that time.

    I could not get the error logs to work, wasn't focusing on this, but
    the diagnostic logs are fine.