### PR TITLE
This improvement supports the end user having many Kubernetes contexts

### DIFF
--- a/microservices/ga/datamgr/dev/kube-config.sh
+++ b/microservices/ga/datamgr/dev/kube-config.sh
@@ -1,11 +1,29 @@
 {{define "dev/kube-config.sh"}}
 #!/bin/bash
 
-CMD0="microk8s.config"
-CMD1=`microk8s.config > $HOME/.kube/config`
+K8SCONFIG="microk8s.config"
+K8SCONTEXT="microk8s"
 
 clear
-echo "Writing microk8s.config to $HOME/.kube/config"
-echo "microk8s.config > $HOME/.kube/config"
-$CMD1
+echo "Saving ${K8SCONFIG} to ${HOME}/.kube/config"
+echo "gathering microk8s configuration "
+
+clusterName=`${K8SCONFIG} | yq r - clusters[0].name`
+clusterServer=`${K8SCONFIG} | yq r - clusters[0].cluster.server`
+clusterCertificate=`${K8SCONFIG} | yq r - clusters[0].cluster.certificate-authority-data`
+userName=`microk8s.config | yq r - users[0].name`
+userToken=`${K8SCONFIG} | yq r - users[0].user.token`
+
+# Add/update the server and the user
+echo "Saving / updating ${K8SCONTEXT}"
+kubectl config set-cluster ${clusterName} --server=${clusterServer}
+kubectl config set clusters.${clusterName}.certificate-authority-data ${clusterCertificate}
+
+kubectl config set-credentials ${userName}
+kubectl config set users.${userName}.token ${userToken}
+
+# Add context and use it
+kubectl config set-context microk8s --cluster=${clusterName} --user=${userName}
+kubectl config set current-context microk8s
+
 {{/* vim: set filetype=gotexttmpl: */ -}}{{end}}

--- a/microservices/ga/workerPool/dev/kube-config.sh
+++ b/microservices/ga/workerPool/dev/kube-config.sh
@@ -1,11 +1,29 @@
 {{define "dev/kube-config.sh"}}
 #!/bin/bash
 
-CMD0="microk8s.config"
-CMD1=`microk8s.config > $HOME/.kube/config`
+K8SCONFIG="microk8s.config"
+K8SCONTEXT="microk8s"
 
 clear
-echo "Writing microk8s.config to $HOME/.kube/config"
-echo "microk8s.config > $HOME/.kube/config"
-$CMD1
+echo "Saving ${K8SCONFIG} to ${HOME}/.kube/config"
+echo "gathering microk8s configuration "
+
+clusterName=`${K8SCONFIG} | yq r - clusters[0].name`
+clusterServer=`${K8SCONFIG} | yq r - clusters[0].cluster.server`
+clusterCertificate=`${K8SCONFIG} | yq r - clusters[0].cluster.certificate-authority-data`
+userName=`microk8s.config | yq r - users[0].name`
+userToken=`${K8SCONFIG} | yq r - users[0].user.token`
+
+# Add/update the server and the user
+echo "Saving / updating ${K8SCONTEXT}"
+kubectl config set-cluster ${clusterName} --server=${clusterServer}
+kubectl config set clusters.${clusterName}.certificate-authority-data ${clusterCertificate}
+
+kubectl config set-credentials ${userName}
+kubectl config set users.${userName}.token ${userToken}
+
+# Add context and use it
+kubectl config set-context microk8s --cluster=${clusterName} --user=${userName}
+kubectl config set current-context microk8s
+
 {{/* vim: set filetype=gotexttmpl: */ -}}{{end}}


### PR DESCRIPTION
Rather than just replacing ~/.kube/config with the microk8s.config.  We
now parse the microk8s.config and then insert or update it into the

Rather than just replacing ~/.kube/config with the microk8s.config.  We
now parse the microk8s.config and then insert or update it into the
default configuration file.

fixes pavedroad-io/templates#119
closes pavedroad-io/templates#119
